### PR TITLE
Make 10-update-timesync writable by root only

### DIFF
--- a/desktop/network/time-sync.rst
+++ b/desktop/network/time-sync.rst
@@ -113,9 +113,9 @@ The following script is inspired by the ArchLinux wiki, to be placed in
 .. literalinclude:: ../config-files/etc/NetworkManager/dispatcher.d/10-update-timesyncd
 
 
-Make it executable by the **root** user only::
+Make it executable and writable by the **root** user only::
 
-    $ chmod 0764 /etc/NetworkManager/dispatcher.d/10-update-timesyncd
+    $ chmod 0744 /etc/NetworkManager/dispatcher.d/10-update-timesyncd
 
 References
 ----------


### PR DESCRIPTION
Otherwise `find-scripts` will fail. See the following syslog excerpt:

```
<redacted> nm-dispatcher: req:9 'connectivity-change': find-scripts: Cannot execute '/etc/NetworkManager/dispatcher.d/10-update-timesyncd': writable by group or other, or set-UID.
```